### PR TITLE
updated to use rest framework landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The Forwarders
 end point = http://127.0.0.1:8000/mail_serv/
 #required header:#
 Content-Type:application/json
-X-CSRFToken:<Token Value>
 #body:#
 {"email": "<email>"}
 
@@ -32,7 +31,7 @@ Content-Type:application/json
 "name": "http.response.status",
 "value": "HTTP/1.1 200",
 "url": "media/uploads/1700846721.748402-testpdf.pdf",
-"status": "upload complete"
+"result": "<message returned>"
 }
 
 # User Account Creation

--- a/backend/file_serv/serializers.py
+++ b/backend/file_serv/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from authentication.models import User
+from django.contrib import auth
+from rest_framework.exceptions import AuthenticationFailed
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.utils.encoding import smart_str, force_str, smart_bytes, DjangoUnicodeDecodeError
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.contrib.sites.shortcuts import get_current_site
+from django.urls import reverse
+from authentication.utils import Util
+import datetime
+
+class uploadSerializer(serializers.Serializer):
+    file = serializers.FileField(max_length=None, allow_empty_file=False, use_url=True)
+
+ 

--- a/backend/file_serv/urls.py
+++ b/backend/file_serv/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
-from file_serv.views import upload_file, upload_fileAPI
+from file_serv.views import UploadFileAPIView
 
 urlpatterns = [
-    path('upload/', upload_file, name="upload-file"),
-    path('uploadAPI/', upload_fileAPI, name="upload-file-api"),
+    path('uploadAPI/', UploadFileAPIView.as_view(), name="upload-file-api"),
+    
 ]

--- a/backend/file_serv/views.py
+++ b/backend/file_serv/views.py
@@ -4,67 +4,35 @@ from django.shortcuts import render
 from .forms import UploadFileForm
 from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
+from rest_framework.views import APIView
+from file_serv.serializers import (uploadSerializer)
+from rest_framework.response import Response
+from rest_framework import status
+import json
 
 # Imaginary function to handle an uploaded file.
 from .apps import handle_uploaded_file
 
-@csrf_exempt
-def upload_fileAPI(request):
-    print(request.POST)
-    print(request.FILES)
+class UploadFileAPIView(APIView):
+    serializer_class = uploadSerializer
 
-    if request.method == "POST":
-        message = handle_uploaded_file(request.FILES)
+    def post(self, request):
+        file = request.data
+        message = handle_uploaded_file(file)
+        result = "OK"
+        url = ""
         if message == "File size too large":
-            response = {
-            "name": "http.response.status",
-            "value": "HTTP/1.1 400",
-            "message": "file size too large"
-	        }
-            return JsonResponse(response)
+            result = "File size too large"
         elif message == "Unacceptable file type":
-            response = {
-            "name": "http.response.status",
-            "value": "HTTP/1.1 400",
-            "message": "unacceptable file type!"
-	        }
-
-            return JsonResponse(response)
+            result = "Unacceptable file type"
         else:
             url = message
-            response = {
-            "name": "http.response.status",
-            "value": "HTTP/1.1 200",
-            "url": f"{url}",
-            "status": "upload complete"
-	        }
 
-            response = JsonResponse(response)
-            return response
+        filler  = {}
+        filler["url"] = url
+        filler["result"] = result
+        payload = json.dumps(filler)
+     
+        return Response(payload, status=status.HTTP_200_OK)
 
-    response = {
-	    "name": "http.response.status",
-	    "value": "HTTP/1.1 400",
-        "message": "only POST request is accepted"
-	}
-    return JsonResponse(response)
-
-@csrf_exempt
-def upload_file(request):
-    print(request.POST)
-    print(request.FILES)
-    if request.method == "POST":
-        form = UploadFileForm(request.POST, request.FILES)
-        if form.is_valid():
-            message = handle_uploaded_file(request.FILES)
-            if message == "File size too large":
-                return render(request,"registration/upload.html",{"form": form, "body": "File size too large!"})
-            elif message == "Unacceptable file type":
-                return render(request,"registration/upload.html",{"form": form, "body": "Unacceptable file type!"})
-
-            else:
-                url = message
-                return render(request,"registration/upload.html",{"form": form, "message": "File Upload Complete = ","url": f"{url}"})
-    else:
-        form = UploadFileForm()
-    return render(request, "registration/upload.html", {"form": form})
+    

--- a/backend/mail_serv/serializers.py
+++ b/backend/mail_serv/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from authentication.models import User
+from django.contrib import auth
+from rest_framework.exceptions import AuthenticationFailed
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.utils.encoding import smart_str, force_str, smart_bytes, DjangoUnicodeDecodeError
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.contrib.sites.shortcuts import get_current_site
+from django.urls import reverse
+from authentication.utils import Util
+import datetime
+
+class passReset(serializers.Serializer):
+    email = serializers.EmailField(max_length=255, min_length=3)
+
+ 

--- a/backend/mail_serv/urls.py
+++ b/backend/mail_serv/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
 
-from .views import redirect_view
+from .views import passwordResetAPI
 
 from . import views
 
 urlpatterns = [
 path('send_mail/', views.mail_serv),
-path('', views.redirect_view), 
+path('', passwordResetAPI.as_view()), 
 ]

--- a/backend/mail_serv/views.py
+++ b/backend/mail_serv/views.py
@@ -5,12 +5,26 @@ from django.shortcuts import redirect
 import requests
 import json
 from django.views.decorators.csrf import csrf_exempt
+from rest_framework.views import APIView
+from mail_serv.serializers import passReset
 
 # Create your views here.
 ## This is only temporary so that we can repurpose if we want to send email notifications other than password
 ## reset
 
-@csrf_exempt
+#For password reset API
+class passwordResetAPI(APIView):
+    serializer_class = passReset
+  
+    def post(self, request):
+        #redirects with internal post request to django-rest-auth password reset endpoint
+        user_email = request.data["email"]
+        redirect_url = request.build_absolute_uri('/dj-rest-auth/password/reset/')
+        payload = requests.post(f'{redirect_url}', data = {'email':f'{user_email}'})
+        message = json.dumps(f"Sent password reset to: {user_email}")
+        response = HttpResponse(message)
+        return response
+
 def mail_serv(request):
     #testing end point http://127.0.0.1:8000/mail_serv/
     #get request body key value pair format {"email":"user email address"}
@@ -45,19 +59,6 @@ def reset(request):
     response = HttpResponse(f"Sent message to {to_mail}:\n\n{message}")
 
     return response 
-
-@csrf_exempt
-def redirect_view(request):
-    #redirects with internal post request to django-rest-auth password reset endpoint
-    package = json.loads(request.body.decode('utf-8'))
-    user_email = package["email"]
-
-    redirect_url = request.build_absolute_uri('/dj-rest-auth/password/reset/')
-    payload = requests.post(f'{redirect_url}', data = {'email':f'{user_email}'})
-    data = json.dumps(f"Sent password reset to: {user_email}")
-    response = HttpResponse(data)
-    return response
-
 
 
     


### PR DESCRIPTION
I made some updates to clean up the API for the file upload and password reset. It should be consistent with using the rest framework with other functions now. Can be tested by going to endpoints in readme. 

>>password reset isn't working. Backend is working through postman and rest framework page so it seems to be something that changed on front end but I haven't found it yet. 
<img width="1066" alt="Screenshot 2023-11-28 at 12 49 46 AM" src="https://github.com/DHClimber/Team-5/assets/145213551/1d193cd9-8cb7-49fa-8761-93ab509572b3">
<img width="1110" alt="Screenshot 2023-11-28 at 12 50 00 AM" src="https://github.com/DHClimber/Team-5/assets/145213551/df922783-ec92-4fdb-b7e6-0ef9406331f9">
